### PR TITLE
docs: fix README version badge to use dynamic Maven Central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PhonePe B2B Payment Gateway SDK for Java
 
-[![Maven Central](https://img.shields.io/badge/Maven%20Central-v2.2.1-blue)](https://maven-badges.herokuapp.com/maven-central/com.phonepe/pg-sdk-java)
+[![Maven Central](https://img.shields.io/maven-central/v/com.phonepe/pg-sdk-java)](https://central.sonatype.com/artifact/com.phonepe/pg-sdk-java)
 ![Java](https://img.shields.io/badge/Java-17%2B-orange)
 [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](LICENSE)
 


### PR DESCRIPTION
#### Description

Replace the hardcoded v2.2.1 static badge with a dynamic shields.io badge that auto-fetches the latest version from Maven Central. This eliminates the need to manually update the badge on every release.

#### Related Issue

Fixes #40

#### Changes Made

- Replaced static Maven Central badge (v2.2.1) with dynamic `shields.io/maven-central` badge
- Updated badge link to point to Sonatype Central artifact page

#### How to Test

1. Verify the badge on the README renders the current version (2.2.3)

#### Checklist

- [x] I have read the CONTRIBUTING.md guide
- [x] Code follows the project's style guidelines
- [x] Tests added for new functionality (if applicable) — N/A, docs only
- [x] All tests pass (`mvn clean verify`)
- [x] Documentation updated (if applicable)
