### PR TITLE
chore: add .editorconfig to enforce consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# EditorConfig: https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.java]
+indent_style = tab
+tab_width = 4
+
+[*.xml]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.properties]
+charset = utf-8


### PR DESCRIPTION
#### Description

Add an .editorconfig file to enforce consistent formatting across all editors. Settings match the existing Spotless and formatter.xml configuration so contributors get the right indentation out of the box.

#### Related Issue

Fixes #43

#### Changes Made

- Added .editorconfig at the repo root with:
  - Tab indentation for Java files (matches formatter.xml)
  - Space indentation for XML and YAML files
  - UTF-8 charset and LF line endings
  - Final newline insertion (matches Spotless endWithNewline)
  - Preserve trailing whitespace in Markdown files

#### How to Test

1. Open a Java file in VS Code or IntelliJ — editor should auto-use tabs
2. Open a YAML file — editor should auto-use 2-space indentation

#### Checklist

- [x] I have read the CONTRIBUTING.md guide
- [x] Code follows the project's style guidelines
- [x] Tests added for new functionality (if applicable) — N/A, config only
- [x] All tests pass (`mvn clean verify`)
- [x] Documentation updated (if applicable)
