### PR TITLE
docs: add class-level Javadoc to BaseClient, CustomCheckoutClient, and SubscriptionClient

### DIFF
--- a/src/main/java/com/phonepe/sdk/pg/common/BaseClient.java
+++ b/src/main/java/com/phonepe/sdk/pg/common/BaseClient.java
@@ -37,6 +37,17 @@ import lombok.SneakyThrows;
 import okhttp3.OkHttpClient;
 
 @Getter
+/**
+ * Abstract base class for all PhonePe Payment Gateway SDK clients.
+ *
+ * <p>Provides shared functionality including OAuth2 token management,
+ * authenticated HTTP request execution with automatic token refresh,
+ * and SDK event telemetry publishing.</p>
+ *
+ * @see com.phonepe.sdk.pg.payments.v2.StandardCheckoutClient
+ * @see com.phonepe.sdk.pg.payments.v2.CustomCheckoutClient
+ * @see com.phonepe.sdk.pg.subscription.v2.SubscriptionClient
+ */
 public abstract class BaseClient {
 
 	private final ObjectMapper objectMapper;

--- a/src/main/java/com/phonepe/sdk/pg/payments/v2/CustomCheckoutClient.java
+++ b/src/main/java/com/phonepe/sdk/pg/payments/v2/CustomCheckoutClient.java
@@ -50,6 +50,21 @@ import java.util.Collections;
 import java.util.List;
 import lombok.SneakyThrows;
 
+/**
+ * The CustomCheckout client class provides methods for interacting with
+ * PhonePe's Custom Checkout Payment Gateway APIs.
+ *
+ * <p>Use this client when you need full control over the payment experience,
+ * including direct card/token instrument handling with PCI-compliant routing
+ * and device OS header injection.</p>
+ *
+ * <p>For a simpler integration where PhonePe handles the checkout UI,
+ * use {@link StandardCheckoutClient} instead.</p>
+ *
+ * @see StandardCheckoutClient
+ * @see com.phonepe.sdk.pg.subscription.v2.SubscriptionClient
+ * @see com.phonepe.sdk.pg.common.BaseClient
+ */
 public class CustomCheckoutClient extends BaseClient {
 
 	private List<HttpHeaderPair> headers;

--- a/src/main/java/com/phonepe/sdk/pg/subscription/v2/SubscriptionClient.java
+++ b/src/main/java/com/phonepe/sdk/pg/subscription/v2/SubscriptionClient.java
@@ -43,6 +43,20 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.SneakyThrows;
 
+/**
+ * The Subscription client class provides methods for interacting with
+ * PhonePe's Subscription (Autopay) Payment Gateway APIs.
+ *
+ * <p>Use this client to manage recurring payment mandates, including
+ * setup, notification, redemption, cancellation, and status queries.</p>
+ *
+ * <p>For one-time payments, use {@link com.phonepe.sdk.pg.payments.v2.StandardCheckoutClient}
+ * or {@link com.phonepe.sdk.pg.payments.v2.CustomCheckoutClient} instead.</p>
+ *
+ * @see com.phonepe.sdk.pg.payments.v2.StandardCheckoutClient
+ * @see com.phonepe.sdk.pg.payments.v2.CustomCheckoutClient
+ * @see com.phonepe.sdk.pg.common.BaseClient
+ */
 public class SubscriptionClient extends BaseClient {
 
 	private List<HttpHeaderPair> headers;


### PR DESCRIPTION
#### Description

Add class-level Javadoc to the three client classes that were missing documentation. StandardCheckoutClient already has one this brings the other three to the same standard.

#### Related Issue

Fixes #45

#### Changes Made

- BaseClient: document its role as shared abstract base for OAuth token management, HTTP execution, and event telemetry
- CustomCheckoutClient: document PCI-compliant card/token routing and device OS header injection
- SubscriptionClient: document autopay flows (setup, notify, redeem, cancel, status)
- Added @see cross-references between all client classes

#### How to Test

1. Open any of the three classes in an IDE and verify Javadoc tooltip appears on hover

#### Checklist

- [x] I have read the CONTRIBUTING.md guide
- [x] Code follows the project's style guidelines (`mvn spotless:apply`)
- [x] Tests added for new functionality (if applicable) — N/A, docs only
- [x] All tests pass (`mvn clean verify`)
- [x] Documentation updated (if applicable)
