### PR TITLE
chore: add GitHub Issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,97 @@
+name: Bug Report
+description: Create a report to help us improve the SDK
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: dropdown
+    id: sdk_version
+    attributes:
+      label: SDK Version
+      description: What version of the pg-sdk-java are you using?
+      options:
+        - 2.2.3
+        - 2.2.2
+        - 2.2.1
+        - Other (specify in description)
+    validations:
+      required: true
+  - type: input
+    id: java_version
+    attributes:
+      label: Java Version
+      description: What version of JDK are you using? (e.g., 17, 21)
+    validations:
+      required: true
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      description: Which PhonePe environment does this bug occur in?
+      options:
+        - SANDBOX
+        - PRODUCTION
+    validations:
+      required: true
+  - type: dropdown
+    id: client_type
+    attributes:
+      label: Client Type
+      description: Which SDK client are you using?
+      options:
+        - StandardCheckoutClient
+        - CustomCheckoutClient
+        - SubscriptionClient
+        - BaseClient / Infrastructure
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction_steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this bug?
+      placeholder: |
+        1. Initialize client with...
+        2. Create request...
+        3. Call pay()...
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+  - type: textarea
+    id: error_logs
+    attributes:
+      label: Error Logs or Stack Traces
+      description: Paste any relevant error messages or stack traces here.
+      render: java
+    validations:
+      required: false
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here (screenshots, related issues, etc).
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: PhonePe Developer Documentation
+    url: https://developer.phonepe.com/
+    about: Check the official documentation before opening an issue
+  - name: PhonePe Developer Portal
+    url: https://developer.phonepe.com/v1/reference/java-sdk-standard-checkout
+    about: SDK-specific API reference and integration guide

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature Request
+description: Suggest an idea for this SDK
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest a new feature!
+  - type: input
+    id: summary
+    attributes:
+      label: Feature Summary
+      description: A clear and concise one-line summary of the feature.
+    validations:
+      required: true
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use Case
+      description: Why is this feature needed? What problem does it solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed Solution
+      description: Describe how you think this feature should work.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or features you've considered.
+    validations:
+      required: false
+  - type: checkboxes
+    id: affected_client
+    attributes:
+      label: Affected Client
+      description: Which parts of the SDK would this feature affect?
+      options:
+        - label: StandardCheckout
+        - label: CustomCheckout
+        - label: Subscription
+        - label: Common / Infrastructure
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Add any other context or screenshots about the feature request here.
+    validations:
+      required: false


### PR DESCRIPTION
#### Description

Add structured GitHub Issue templates using GitHub's modern YAML issue forms. This will ensure that incoming bug reports and feature requests contain all the necessary information (like SDK version, environment, and reproduction steps) right from the start, saving maintainers time.

#### Related Issue

Fixes #47

#### Changes Made

- Added `.github/ISSUE_TEMPLATE/bug_report.yml` with dropdowns for SDK version, Java version, Environment (SANDBOX/PRODUCTION), and Client Type.
- Added `.github/ISSUE_TEMPLATE/feature_request.yml` with structured fields for use case and proposed solution.
- Added `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues and link users directly to the PhonePe Developer Documentation.

#### How to Test

1. Navigate to the `Issues` tab on this fork branch.
2. Click `New Issue` and verify that the "Bug Report" and "Feature Request" options appear instead of a blank text box.
3. Verify the link to the PhonePe Developer documentation is visible.

#### Checklist

- [x] I have read the CONTRIBUTING.md guide
- [x] Code follows the project's style guidelines
- [x] Tests added for new functionality (if applicable) — N/A, config only
- [x] All tests pass (`mvn clean verify`)
- [x] Documentation updated (if applicable)
